### PR TITLE
Make the complete purchase request never redirect

### DIFF
--- a/src/Message/CompletePurchaseResponse.php
+++ b/src/Message/CompletePurchaseResponse.php
@@ -4,6 +4,11 @@ namespace Omnipay\Sisow\Message;
 
 class CompletePurchaseResponse extends PurchaseResponse
 {
+    public function isRedirect()
+    {
+        return false;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -37,7 +42,7 @@ class CompletePurchaseResponse extends PurchaseResponse
         if (isset($this->data->transaction) && isset($this->data->transaction->status)) {
             return (string) $this->data->transaction->status;
         }
-        
+
         return null;
     }
 }

--- a/tests/Message/CompletePurchaseRequestTest.php
+++ b/tests/Message/CompletePurchaseRequestTest.php
@@ -37,6 +37,7 @@ class CompletePurchaseRequestTest extends TestCase
         $response = $this->request->send();
 
         $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
     }
 
     public function testSendFailure()


### PR DESCRIPTION
We ran into problems when completing a purchase. The complete purchase response incorrectly marked as being a redirect.
