### PR TITLE
Added support for klarna, removed ecare

### DIFF
--- a/src/Message/FetchPaymentMethodsResponse.php
+++ b/src/Message/FetchPaymentMethodsResponse.php
@@ -10,7 +10,7 @@ class FetchPaymentMethodsResponse extends BaseAbastractResponse implements Fetch
 {
     protected $names = array(
         'ideal' => 'iDEAL',
-        'ecare' => 'ecare',
+        'klarna' => 'Klarna factuur (achteraf betalen)',
         'ebill' => 'ebill',
         'overboeking' => 'Overboeking',
         'sofort' => 'DIRECTebanking/SofortBanking',

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -41,11 +41,58 @@ class PurchaseRequest extends AbstractRequest
         return $this->setParameter('entranceCode', $value);
     }
 
+    public function getMakeInvoice()
+    {
+        return $this->getParameter('makeInvoice') ?: 'true';
+    }
+
+    public function setMakeInvoice($value)
+    {
+        return $this->setParameter('makeInvoice', $value);
+    }
+
+    public function getMailInvoice()
+    {
+        return $this->getParameter('mailInvoice') ?: 'true';
+    }
+
+    public function setMailInvoice($value)
+    {
+        return $this->setParameter('mailInvoice', $value);
+    }
+
+    public function getBillingCountrycode()
+    {
+        return $this->getParameter('billingCountrycode');
+    }
+
+    public function setBillingCountrycode($value)
+    {
+        return $this->setParameter('billingCountrycode', $value);
+    }
+
+    public function getShippingCountrycode()
+    {
+        return $this->getParameter('shippingCountrycode');
+    }
+
+    public function setShippingCountrycode($value)
+    {
+        return $this->setParameter('shippingCountrycode', $value);
+    }
+
     /**
      * {@inheritdoc}
      */
     protected function generateSignature()
     {
+        if($this->getPaymentMethod() == 'klarna')
+        {
+            return sha1(
+                $this->getTransactionId() . $this->getEntranceCode() . $this->getAmountInteger() .
+                $this->getShopId() . $this->getMerchantId() . $this->getMerchantKey()
+            );
+        }
         return sha1(
             $this->getTransactionId() . $this->getEntranceCode() .
             $this->getAmountInteger() . $this->getMerchantId() . $this->getMerchantKey()
@@ -90,39 +137,68 @@ class PurchaseRequest extends AbstractRequest
         /** @var \Omnipay\Common\CreditCard $card */
         $card = $this->getCard();
         if ($card) {
-            if ($this->getPaymentMethod() == 'overboeking' || $this->getPaymentMethod() == 'ecare') {
+            if ($this->getPaymentMethod() == 'overboeking' || $this->getPaymentMethod() == 'klarna') {
                 $data['billing_mail']       = $card->getEmail();
                 $data['billing_firstname']  = $card->getBillingFirstName();
                 $data['billing_lastname']   = $card->getBillingLastName();
             }
 
-            if ($this->getPaymentMethod() == 'ecare') {
-                $data['billing_company']    = $card->getBillingCompany();
-                $data['billing_address1']   = $card->getBillingAddress1();
-                $data['billing_address2']   = $card->getBillingAddress2();
-                $data['billing_zip']        = $card->getBillingPostcode();
-                $data['billing_city']       = $card->getBillingCity();
-                $data['billing_country']    = $card->getBillingCountry();
-                $data['billing_phone']      = $card->getBillingPhone();
+            if ($this->getPaymentMethod() == 'klarna') {
+                $data['billing_company']        = $card->getBillingCompany();
+                $data['billing_address1']       = $card->getBillingAddress1();
+                $data['billing_address2']       = $card->getBillingAddress2();
+                $data['billing_zip']            = $card->getBillingPostcode();
+                $data['billing_city']           = $card->getBillingCity();
+                $data['billing_country']        = $card->getBillingCountry();
+                $data['billing_phone']          = $card->getBillingPhone();
+                $data['birthdate']              = date('dmY', strtotime($card->getBirthday()));
+                $data['pclass']                 = -1; // only used for klarna account, but required for klarna invoice aswell.
+                $data['makeinvoice']            = $this->getMakeInvoice();
+                $data['mailinvoice']            = $this->getMailInvoice();
+                $data['billing_countrycode']     = $this->getBillingCountrycode();
+                $data['shipping_countrycode']    = $this->getShippingCountrycode();
+
+                $data = array_merge($data, $this->getItemData());
             }
 
-            if ($this->getPaymentMethod() == 'esend') {
-                $data['shipping_mail']       = $card->getEmail();
-                $data['shipping_firstname']  = $card->getShippingFirstName();
-                $data['shipping_lastname']   = $card->getShippingLastName();
-                $data['shipping_company']    = $card->getShippingCompany();
-                $data['shipping_address1']   = $card->getShippingAddress1();
-                $data['shipping_address2']   = $card->getShippingAddress2();
-                $data['shipping_zip']        = $card->getShippingPostcode();
-                $data['shipping_city']       = $card->getShippingCity();
-                $data['shipping_country']    = $card->getShippingCountry();
-                $data['shipping_phone']      = $card->getShippingPhone();
+            $data['shipping_mail']       = $card->getEmail();
+            $data['shipping_firstname']  = $card->getShippingFirstName();
+            $data['shipping_lastname']   = $card->getShippingLastName();
+            $data['shipping_company']    = $card->getShippingCompany();
+            $data['shipping_address1']   = $card->getShippingAddress1();
+            $data['shipping_address2']   = $card->getShippingAddress2();
+            $data['shipping_zip']        = $card->getShippingPostcode();
+            $data['shipping_city']       = $card->getShippingCity();
+            $data['shipping_country']    = $card->getShippingCountry();
+            $data['shipping_phone']      = $card->getShippingPhone();
+        }
+
+        return $data;
+    }
+
+    protected function getItemData()
+    {
+        $data = array();
+        $items = $this->getItems();
+
+        if ($items)
+        {
+            foreach ($items as $i => $item)
+            {
+                $data['product_id_'.$i] = $item->getName();
+                $data['product_description_'.$i] = $item->getDescription();
+                $data['product_quantity_'.$i] = $item->getQuantity();
+                $data['product_netprice_'.$i] = ceil($this->formatCurrency($item->getPrice()) * 100);
+                $data['product_total_'.$i] = ceil($this->formatCurrency($item->getPrice()) * $item->getQuantity() * 100);
+                $data['product_nettotal_'.$i] = ceil(($this->formatCurrency($item->getPrice())/121*100) * $item->getQuantity() * 100); //@todo fix tax rates
+                $data['product_tax_'.$i] = ceil(($this->formatCurrency($item->getPrice())/121*21) * 100);
+                $data['product_taxrate_'.$i] = 21 * 100;
             }
         }
 
         return $data;
     }
-    
+
     /**
      * {@inheritdoc}
      */

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -110,7 +110,7 @@ class PurchaseRequest extends AbstractRequest
             'notifyUrl'
         );
 
-        if ( ! $this->getTestMode() && $this->getIssuer() == 99) {
+        if (!$this->getTestMode() && $this->getIssuer() == 99) {
             throw new InvalidRequestException("The issuer can only be '99' in testMode!");
         }
 

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -86,8 +86,7 @@ class PurchaseRequest extends AbstractRequest
      */
     protected function generateSignature()
     {
-        if($this->getPaymentMethod() == 'klarna')
-        {
+        if ($this->getPaymentMethod() == 'klarna') {
             return sha1(
                 $this->getTransactionId() . $this->getEntranceCode() . $this->getAmountInteger() .
                 $this->getShopId() . $this->getMerchantId() . $this->getMerchantKey()
@@ -111,66 +110,68 @@ class PurchaseRequest extends AbstractRequest
             'notifyUrl'
         );
 
-        if (!$this->getTestMode() && $this->getIssuer() == 99) {
+        if ( ! $this->getTestMode() && $this->getIssuer() == 99) {
             throw new InvalidRequestException("The issuer can only be '99' in testMode!");
         }
 
         $data = array(
-            'shopid'        => $this->getShopId(),
-            'merchantid'    => $this->getMerchantId(),
-            'merchantkey'   => $this->getMerchantKey(),
-            'payment'       => $this->getPaymentMethod(),
-            'purchaseid'    => $this->getTransactionId(),
-            'amount'        => $this->getAmountInteger(),
-            'issuerid'      => $this->getIssuer(),
-            'entrancecode'  => $this->getEntranceCode(),
-            'description'   => $this->getDescription(),
-            'including'     => $this->getIncluding(),
-            'days'          => $this->getDays(),
-            'returnurl'     => $this->getReturnUrl(),
-            'cancelurl'     => $this->getCancelUrl(),
-            'notifyurl'     => $this->getNotifyUrl(),
-            'sha1'          => $this->generateSignature(),
-            'testmode'      => $this->getTestMode(),
+            'shopid' => $this->getShopId(),
+            'merchantid' => $this->getMerchantId(),
+            'merchantkey' => $this->getMerchantKey(),
+            'payment' => $this->getPaymentMethod(),
+            'purchaseid' => $this->getTransactionId(),
+            'amount' => $this->getAmountInteger(),
+            'issuerid' => $this->getIssuer(),
+            'entrancecode' => $this->getEntranceCode(),
+            'description' => $this->getDescription(),
+            'including' => $this->getIncluding(),
+            'days' => $this->getDays(),
+            'returnurl' => $this->getReturnUrl(),
+            'cancelurl' => $this->getCancelUrl(),
+            'notifyurl' => $this->getNotifyUrl(),
+            'sha1' => $this->generateSignature(),
+            'testmode' => $this->getTestMode(),
         );
 
         /** @var \Omnipay\Common\CreditCard $card */
         $card = $this->getCard();
         if ($card) {
             if ($this->getPaymentMethod() == 'overboeking' || $this->getPaymentMethod() == 'klarna') {
-                $data['billing_mail']       = $card->getEmail();
-                $data['billing_firstname']  = $card->getBillingFirstName();
-                $data['billing_lastname']   = $card->getBillingLastName();
+                $data['billing_mail'] = $card->getEmail();
+                $data['billing_firstname'] = $card->getBillingFirstName();
+                $data['billing_lastname'] = $card->getBillingLastName();
             }
 
             if ($this->getPaymentMethod() == 'klarna') {
-                $data['billing_company']        = $card->getBillingCompany();
-                $data['billing_address1']       = $card->getBillingAddress1();
-                $data['billing_address2']       = $card->getBillingAddress2();
-                $data['billing_zip']            = $card->getBillingPostcode();
-                $data['billing_city']           = $card->getBillingCity();
-                $data['billing_country']        = $card->getBillingCountry();
-                $data['billing_phone']          = $card->getBillingPhone();
-                $data['birthdate']              = date('dmY', strtotime($card->getBirthday()));
-                $data['pclass']                 = -1; // only used for klarna account, but required for klarna invoice aswell.
-                $data['makeinvoice']            = $this->getMakeInvoice();
-                $data['mailinvoice']            = $this->getMailInvoice();
-                $data['billing_countrycode']     = $this->getBillingCountrycode();
-                $data['shipping_countrycode']    = $this->getShippingCountrycode();
+                $data['billing_company'] = $card->getBillingCompany();
+                $data['billing_address1'] = $card->getBillingAddress1();
+                $data['billing_address2'] = $card->getBillingAddress2();
+                $data['billing_zip'] = $card->getBillingPostcode();
+                $data['billing_city'] = $card->getBillingCity();
+                $data['billing_country'] = $card->getBillingCountry();
+                $data['billing_phone'] = $card->getBillingPhone();
+                $data['birthdate'] = date('dmY', strtotime($card->getBirthday()));
+                $data['makeinvoice'] = $this->getMakeInvoice();
+                $data['mailinvoice'] = $this->getMailInvoice();
+                $data['billing_countrycode'] = $this->getBillingCountrycode();
+                $data['shipping_countrycode'] = $this->getShippingCountrycode();
+
+                // only used for klarna account (required for klarna invoice as -1)
+                $data['pclass'] = - 1;
 
                 $data = array_merge($data, $this->getItemData());
             }
 
-            $data['shipping_mail']       = $card->getEmail();
-            $data['shipping_firstname']  = $card->getShippingFirstName();
-            $data['shipping_lastname']   = $card->getShippingLastName();
-            $data['shipping_company']    = $card->getShippingCompany();
-            $data['shipping_address1']   = $card->getShippingAddress1();
-            $data['shipping_address2']   = $card->getShippingAddress2();
-            $data['shipping_zip']        = $card->getShippingPostcode();
-            $data['shipping_city']       = $card->getShippingCity();
-            $data['shipping_country']    = $card->getShippingCountry();
-            $data['shipping_phone']      = $card->getShippingPhone();
+            $data['shipping_mail'] = $card->getEmail();
+            $data['shipping_firstname'] = $card->getShippingFirstName();
+            $data['shipping_lastname'] = $card->getShippingLastName();
+            $data['shipping_company'] = $card->getShippingCompany();
+            $data['shipping_address1'] = $card->getShippingAddress1();
+            $data['shipping_address2'] = $card->getShippingAddress2();
+            $data['shipping_zip'] = $card->getShippingPostcode();
+            $data['shipping_city'] = $card->getShippingCity();
+            $data['shipping_country'] = $card->getShippingCountry();
+            $data['shipping_phone'] = $card->getShippingPhone();
         }
 
         return $data;
@@ -181,18 +182,20 @@ class PurchaseRequest extends AbstractRequest
         $data = array();
         $items = $this->getItems();
 
-        if ($items)
-        {
-            foreach ($items as $i => $item)
-            {
-                $data['product_id_'.$i] = $item->getName();
-                $data['product_description_'.$i] = $item->getDescription();
-                $data['product_quantity_'.$i] = $item->getQuantity();
-                $data['product_netprice_'.$i] = ceil($this->formatCurrency($item->getPrice()) * 100);
-                $data['product_total_'.$i] = ceil($this->formatCurrency($item->getPrice()) * $item->getQuantity() * 100);
-                $data['product_nettotal_'.$i] = ceil(($this->formatCurrency($item->getPrice())/121*100) * $item->getQuantity() * 100); //@todo fix tax rates
-                $data['product_tax_'.$i] = ceil(($this->formatCurrency($item->getPrice())/121*21) * 100);
-                $data['product_taxrate_'.$i] = 21 * 100;
+        if ($items) {
+            foreach ($items as $i => $item) {
+                $data['product_id_' . $i] = $item->getName();
+                $data['product_description_' . $i] = $item->getDescription();
+                $data['product_quantity_' . $i] = $item->getQuantity();
+                $data['product_netprice_' . $i] = ceil($this->formatCurrency($item->getPrice()) * 100);
+                $data['product_total_' . $i] = ceil(
+                    $this->formatCurrency($item->getPrice()) * $item->getQuantity() * 100
+                );
+                $data['product_nettotal_' . $i] = ceil(
+                    ($this->formatCurrency($item->getPrice()) / 121 * 100) * $item->getQuantity() * 100
+                ); //@todo fix tax rates
+                $data['product_tax_' . $i] = ceil(($this->formatCurrency($item->getPrice()) / 121 * 21) * 100);
+                $data['product_taxrate_' . $i] = 21 * 100;
             }
         }
 

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -43,7 +43,7 @@ class PurchaseRequest extends AbstractRequest
 
     public function getMakeInvoice()
     {
-        return $this->getParameter('makeInvoice') ?: 'true';
+        return $this->getParameter('makeInvoice');
     }
 
     public function setMakeInvoice($value)
@@ -53,7 +53,7 @@ class PurchaseRequest extends AbstractRequest
 
     public function getMailInvoice()
     {
-        return $this->getParameter('mailInvoice') ?: 'true';
+        return $this->getParameter('mailInvoice');
     }
 
     public function setMailInvoice($value)
@@ -110,7 +110,7 @@ class PurchaseRequest extends AbstractRequest
             'notifyUrl'
         );
 
-        if (!$this->getTestMode() && $this->getIssuer() == 99) {
+        if ( ! $this->getTestMode() && $this->getIssuer() == 99) {
             throw new InvalidRequestException("The issuer can only be '99' in testMode!");
         }
 
@@ -151,8 +151,12 @@ class PurchaseRequest extends AbstractRequest
                 $data['billing_country'] = $card->getBillingCountry();
                 $data['billing_phone'] = $card->getBillingPhone();
                 $data['birthdate'] = date('dmY', strtotime($card->getBirthday()));
-                $data['makeinvoice'] = $this->getMakeInvoice();
-                $data['mailinvoice'] = $this->getMailInvoice();
+                if ($this->getMakeInvoice()) {
+                    $data['makeinvoice'] = $this->getMakeInvoice();
+                }
+                if ($this->getMailInvoice()) {
+                    $data['mailinvoice'] = $this->getMailInvoice();
+                }
                 $data['billing_countrycode'] = $this->getBillingCountrycode();
                 $data['shipping_countrycode'] = $this->getShippingCountrycode();
 

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -4,6 +4,7 @@ namespace Omnipay\Sisow\Message;
 
 use Mockery as m;
 use Omnipay\Tests\TestCase;
+use Omnipay\Common\CreditCard;
 
 class PurchaseRequestTest extends TestCase
 {
@@ -17,6 +18,10 @@ class PurchaseRequestTest extends TestCase
         $arguments = array($this->getHttpClient(), $this->getHttpRequest());
         $this->request = m::mock('Omnipay\Sisow\Message\PurchaseRequest[getEndpoint]', $arguments);
 
+        $card = new CreditCard($this->getValidCard());
+        $card->setBirthday('01-02-2000');
+
+        $this->request->setCard($card);
         $this->request->setShopId('0');
         $this->request->setMerchantId('0123456');
         $this->request->setMerchantKey('b36d8259346eaddb3c03236b37ad3a1d7a67cec6');
@@ -24,6 +29,25 @@ class PurchaseRequestTest extends TestCase
         $this->request->setTransactionId('123');
         $this->request->setReturnUrl('http://localhost/return');
         $this->request->setNotifyUrl('http://localhost/notify');
+    }
+
+    public function testKlarna()
+    {
+        // setup klarna specific setters
+        $this->request->setPaymentMethod('klarna');
+        $this->request->setMakeInvoice('true');
+        $this->request->setMailInvoice('true');
+        $this->request->setBillingCountrycode('nl');
+        $this->request->setShippingCountrycode('nl');
+
+        $data = $this->request->getData();
+
+        $this->assertSame('true', $data['makeinvoice']);
+        $this->assertSame('true', $data['mailinvoice']);
+        $this->assertSame('nl', $data['billing_countrycode']);
+        $this->assertSame('nl', $data['shipping_countrycode']);
+
+        $this->assertSame('01022000', $data['birthdate']);
     }
 
     public function testSendSuccess()
@@ -34,7 +58,8 @@ class PurchaseRequestTest extends TestCase
 
         $this->assertFalse($response->isSuccessful());
         $this->assertTrue($response->isRedirect());
-        $this->assertEquals('https://www.sisow.nl/Sisow/iDeal/Simulator.aspx?merchantid=0123456&txid=TEST080494974182&sha1=ae6c5ca5daac1a3e907f0bb9014bf2c6c2caa0f2', $response->getRedirectUrl());
+        $this->assertEquals('https://www.sisow.nl/Sisow/iDeal/Simulator.aspx?merchantid=0123456&txid=TEST080494974182&sha1=ae6c5ca5daac1a3e907f0bb9014bf2c6c2caa0f2',
+            $response->getRedirectUrl());
         $this->assertEquals('TEST080494974282', $response->getTransactionReference());
     }
 
@@ -46,7 +71,8 @@ class PurchaseRequestTest extends TestCase
 
         $this->assertFalse($response->isSuccessful());
         $this->assertTrue($response->isRedirect());
-        $this->assertEquals('https://www.sisow.nl/Sisow/iDeal/RestPay.aspx?id=80494974814&merchantid=0123456&sha1=b3dc1ac353e3983b3e9ba285de1b1f3d774fc8c9', $response->getRedirectUrl());
+        $this->assertEquals('https://www.sisow.nl/Sisow/iDeal/RestPay.aspx?id=80494974814&merchantid=0123456&sha1=b3dc1ac353e3983b3e9ba285de1b1f3d774fc8c9',
+            $response->getRedirectUrl());
         $this->assertEquals(null, $response->getTransactionReference());
     }
 


### PR DESCRIPTION
Since sisow dropped ecare support a while ago, I have replaced this with the syntax of their current "achteraf betalen" partner klarna.

I also changed the esend shipping data to be send always. If a sisow account supports esend, it can use this data to create an esend request from the sisow control panel without having to enter the users data manually.

In this pull request everything is psr2 :-)
